### PR TITLE
fix: table column inference and a few other goodies

### DIFF
--- a/apps/zoos/src/routes/core/react-form/select.tsx
+++ b/apps/zoos/src/routes/core/react-form/select.tsx
@@ -1,21 +1,21 @@
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute } from "@tanstack/react-router";
 
-export const Route = createFileRoute('/core/react-form/select')({
+export const Route = createFileRoute("/core/react-form/select")({
   component: RouteComponent,
-})
+});
 
-import React from 'react'
-import { Select, getOptions } from '@zoos/react-form'
+import React from "react";
+import { Select, getOptions } from "@zoos/react-form";
 
 const options = getOptions({
-  values: ['1', '2', '3', '4'],
+  values: ["1", "2", "3", "4"],
   // Optional getLabel function
   // (defaults to (value) => value)
   getLabel: (value) => `Option ${value}`,
-})
+});
 
 function RouteComponent() {
-  const [value, setValue] = React.useState<string | undefined>(undefined)
+  const [value, setValue] = React.useState<string | undefined>(undefined);
 
   return (
     <Select
@@ -26,5 +26,5 @@ function RouteComponent() {
       sort={true}
       placeholder="Optional placeholder"
     />
-  )
+  );
 }

--- a/apps/zoos/src/routes/core/react-table/column-filters.tsx
+++ b/apps/zoos/src/routes/core/react-table/column-filters.tsx
@@ -82,23 +82,13 @@ const columns = [
     filterFn: filters.number.range.filterFn,
     meta: {
       Filter: (headerContext) => {
-        const [autoRefresh, setAutoRefresh] = React.useState(true);
         return (
           <FilterContainer>
-            <div className="ml-auto">
-              <AutoRefreshToggle
-                pressed={autoRefresh}
-                onPressedChange={setAutoRefresh}
-              />
-            </div>
             <Label>
               <FormattedId headerContext={headerContext} /> Range
               <span className="text-secondary ml-1">(number.range)</span>
             </Label>
-            <filters.number.range.FilterInput
-              headerContext={headerContext}
-              autoRefresh={autoRefresh}
-            />
+            <filters.number.range.FilterInput headerContext={headerContext} />
             <ClearFilterButton headerContext={headerContext} />
           </FilterContainer>
         );

--- a/packages/react-form/src/components/select.tsx
+++ b/packages/react-form/src/components/select.tsx
@@ -16,13 +16,18 @@ const Select = (props: {
   className?: string;
   placeholder?: string;
   sort?: boolean;
+  disabled?: boolean;
 }) => {
   const options = props.sort
     ? props.options.sort((a, b) => a.label.localeCompare(b.label))
     : props.options;
 
   return (
-    <SelectPrimitive value={props.value} onValueChange={props.onChange}>
+    <SelectPrimitive
+      disabled={props.disabled}
+      value={props.value}
+      onValueChange={props.onChange}
+    >
       <SelectTrigger className={props.className}>
         <SelectValue placeholder={props.placeholder} />
       </SelectTrigger>

--- a/packages/react-grid-layout/package.json
+++ b/packages/react-grid-layout/package.json
@@ -16,7 +16,9 @@
     "access": "public"
   },
   "dependencies": {
-    "@types/react-grid-layout": "^1.3.5",
     "react-grid-layout": "^1.5.0"
+  },
+  "devDependencies": {
+    "@types/react-grid-layout": "^1.3.5"
   }
 }

--- a/packages/react-table-ui/src/filters/number-range.tsx
+++ b/packages/react-table-ui/src/filters/number-range.tsx
@@ -1,12 +1,7 @@
-import React from "react";
-
 import type { Row, HeaderContext } from "@tanstack/react-table";
+import type { NumberRange2InputProps, NumberRange } from "@zoos/react-form";
 
-import {
-  NumberRange2Input,
-  type NumberRange2InputProps,
-  type NumberRange,
-} from "@zoos/react-form";
+import { NumberRange2Input } from "@zoos/react-form";
 
 import { evaluateRangeFilter } from "../filter/lib/evaluate-range-filter";
 
@@ -24,36 +19,22 @@ function filterFn<TData>(
 const FilterInput = <TData, TValue>(props: {
   headerContext: HeaderContext<TData, TValue>;
   inputProps?: NumberRange2InputProps;
-  autoRefresh?: boolean;
 }) => {
   const {
     headerContext: { column },
-    autoRefresh = true,
   } = props;
-  const filterValue = column.getFilterValue();
-  const range = (filterValue || {}) as NumberRange;
-  const [value, setValue] = React.useState(range);
-
-  // When autoRefresh is re-enabled, set the value in the column
-  React.useEffect(() => {
-    if (autoRefresh) {
-      column.setFilterValue(value);
-    }
-  }, [autoRefresh, column, value]);
-
-  React.useEffect(() => {
-    setValue(filterValue ? { ...filterValue } : {});
-  }, [filterValue]);
+  const filterValue = column.getFilterValue() as NumberRange;
+  const minMax = column.getFacetedMinMaxValues();
+  const range = {
+    from: minMax?.[0] || filterValue?.from,
+    to: minMax?.[1] || filterValue?.to,
+  } as NumberRange;
 
   return (
     <NumberRange2Input
-      value={value}
+      value={range}
       onChange={(value) => {
-        if (autoRefresh) {
-          column.setFilterValue(value);
-        } else {
-          setValue(value);
-        }
+        column.setFilterValue(value);
       }}
       {...props.inputProps}
     />

--- a/packages/react-table-ui/src/header/header-context-menu.tsx
+++ b/packages/react-table-ui/src/header/header-context-menu.tsx
@@ -116,6 +116,13 @@ const HeaderContextMenu = <TData, TValue>({
             </ContextMenuPortal>
           </ContextMenuSub>
         )}
+        {header.column.getIsFiltered() && (
+          <ContextMenuItem
+            onClick={() => header.column.setFilterValue(undefined)}
+          >
+            Clear Filter
+          </ContextMenuItem>
+        )}
       </ContextMenuContent>
     </>
   );

--- a/packages/react-table-ui/src/tables/standard.tsx
+++ b/packages/react-table-ui/src/tables/standard.tsx
@@ -79,7 +79,7 @@ const Table = <TData extends object, TValue>(props: {
                               // (See below) comments for `ContextMenu` on `<td />`
                               // for info on `modal={false}`
                             }
-                            <ContextMenu modal={false}>
+                            <ContextMenu modal={true}>
                               <HeaderContextMenu
                                 header={header.getContext()}
                                 {...componentProps.thContextMenu?.({

--- a/packages/react-table/src/lib/column-inference/get-column-types.ts
+++ b/packages/react-table/src/lib/column-inference/get-column-types.ts
@@ -1,0 +1,98 @@
+//
+// parse-type.ts
+// -------------
+// parse data types out of strings or the expected
+// type
+//
+
+const IS_NUMERIC_REGEX = /^[+-]?(?:\d+|\d*\.\d+)(?:[eE][+-]?\d+)?$/;
+
+function isNumeric(value: string | number): boolean {
+  if (typeof value === "number") {
+    return true;
+  }
+
+  if (typeof value !== "string" || !IS_NUMERIC_REGEX.test(value)) {
+    return false;
+  }
+
+  return true;
+}
+
+const IS_DATE_REGEX =
+  /^(?:(?:(\d{1,2})-(\d{1,2})-(\d{2}|\d{4}))|(?:(\d{4}|\d{2})-(\d{1,2})-(\d{1,2})))(?:\s+(\d{1,2}):(\d{2})(?::(\d{2}))?(?:\s*(AM|PM))?)?$/;
+
+function isDate(value: string | Date): boolean {
+  if (value instanceof Date) {
+    return true;
+  }
+
+  if (typeof value !== "string" || !IS_DATE_REGEX.test(value)) {
+    return false;
+  }
+
+  const date = Date.parse(value);
+
+  return !isNaN(date);
+}
+type ValueType =
+  | "string"
+  | "number"
+  | "boolean"
+  | "object"
+  | "function"
+  | "undefined"
+  | "symbol"
+  | "bigint"
+  | "date";
+
+function getType<T>(value: string | T): ValueType {
+  if (value === undefined || value === null) {
+    return "undefined";
+  } else if (isNumeric(value as string | number)) {
+    return "number";
+  } else if (isDate(value as string | Date)) {
+    return "date";
+  } else {
+    return typeof value;
+  }
+}
+
+function getColumnTypes<T extends Record<string, unknown>>(params: {
+  data: T[];
+  columnIds?: string[];
+}): { [key: string]: ValueType } {
+  if (params.data.length === 0) {
+    return {};
+  }
+
+  const { data, columnIds = Object.keys(data[0]) } = params;
+
+  const types = Object.fromEntries(
+    columnIds.map((columnId) => {
+      return [columnId, getType(data[0][columnId])];
+    }),
+  );
+
+  const undefinedKeys = Object.entries(types)
+    .filter(([_, value]) => value === "undefined")
+    .map(([key, _]) => key);
+
+  if (undefinedKeys.length > 0) {
+    for (const columnId of undefinedKeys) {
+      let type: ValueType = types[columnId];
+      let idx = 1;
+      while (type === "undefined" && idx < data.length - 1) {
+        type = getType(data[idx][columnId]);
+        idx++;
+      }
+
+      types[columnId] = type;
+    }
+  }
+
+  return types;
+}
+
+export { getType, getColumnTypes };
+export type { ValueType };

--- a/packages/react-table/src/lib/column-inference/index.ts
+++ b/packages/react-table/src/lib/column-inference/index.ts
@@ -1,2 +1,3 @@
 export * from "./get-columns";
+export * from "./get-column-types";
 export * from "./merge-columns";

--- a/packages/shadcn/src/components/input.tsx
+++ b/packages/shadcn/src/components/input.tsx
@@ -2,6 +2,9 @@ import * as React from "react";
 
 import { cn } from "../lib/utils";
 
+const inputClasses =
+  "bg-input text-input-foreground file:text-foreground placeholder:text-muted-foreground focus-visible:ring-ring flex h-9 w-full rounded border px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-none focus-visible:ring-1 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm";
+
 const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
   ({ className, type, ...props }, ref) => {
     return (
@@ -19,4 +22,4 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
 );
 Input.displayName = "Input";
 
-export { Input };
+export { Input, inputClasses };


### PR DESCRIPTION
- table inference: see example `getColumnDef` in route: `core/react-table/standard`
- react-form select can be disabled
- shadcn input exports `inputClasses`